### PR TITLE
fix missing end quote on nat IP

### DIFF
--- a/geth-entrypoint
+++ b/geth-entrypoint
@@ -39,7 +39,7 @@ if [ "${OP_GETH_BOOTNODES+x}" = x ]; then
 fi
 
 if [ "${HOST_IP:+x}" = x]; then
-	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --nat=extip:$HOST_IP
+	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --nat=extip:$HOST_IP"
 fi 
 
 exec ./geth \


### PR DESCRIPTION
I was trying to set up a base node and was running into an error
```
./geth-entrypoint: line 72: unexpected EOF while looking for matching `"'
```
It appears this is due to a missing end quote on the line:
```sh
ADDITIONAL_ARGS="$ADDITIONAL_ARGS --nat=extip:$HOST_IP
```